### PR TITLE
Make it work if Nix is enabled in Stack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ binary in the PATH.
 unzip -j protoc-*-linux-x86_64.zip bin/protoc -d /usr/local/bin/
 ```
 
+> If you use have Nix installed and you use `stack --nix`, you do not need to do
+> this.
+
 # Build the project
 
 Use the following to build and run tests:

--- a/build-stack.sh
+++ b/build-stack.sh
@@ -21,7 +21,7 @@ export REALGHC=$(stack path --compiler-exe)
 # ghc_kythe_wrapper (from local-install-root) on the PATH. Note that stack
 # wrapper ghc script replaces the system ghc.
 PATH=$PWD/wrappers/stack:$(stack path --compiler-bin):$PATH:$(stack path --local-install-root)/bin \
-  stack --system-ghc build --force-dirty ${@:2}
+  stack --system-ghc build --no-nix --force-dirty ${@:2}
 [[ $? != 0 ]] && fail "Indexing failed!"
 
 # Serve the index

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,3 +39,5 @@ docker:
   # mentioned script which builds it.
   image: hsidx-build
 
+nix:
+  packages: [gcc, protobuf3_2]


### PR DESCRIPTION
If a developer uses Nix and have it globally enabled, it is required to
list which non-Haskell packages to use during build.

Additionally explictly disable nix when stack is run from
./build-stack.sh to ensure that it actually rebuilds these packages
locally.