### PR TITLE
Add references from type signatures

### DIFF
--- a/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
+++ b/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
@@ -376,11 +376,10 @@ refsFromRenamed ctx declAlts (hsGroup, _, _, _) =
     let typeRefs = mapMaybe refsFromHsType (universeBi hsGroup)
         -- TODO(robinpalotai): maybe add context. It would need first finding
         --   the context roots, and only then doing the traversal.
-        sigRefs =
-          case hs_valds hsGroup of
+        sigRefs = case hs_valds hsGroup of
             ValBindsOut _ lsigs -> concatMap refsFromSignature lsigs
             ValBindsIn _ lsigs ->
-              error "should not hit ValBindsIn when accessing renamed AST"
+                error "should not hit ValBindsIn when accessing renamed AST"
         refContext = Nothing
     in map (toTickReference ctx refContext declAlts) (typeRefs ++ sigRefs)
   where

--- a/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
+++ b/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
@@ -376,7 +376,10 @@ refsFromRenamed ctx declAlts (hsGroup, _, _, _) =
     let typeRefs = mapMaybe refsFromHsType (universeBi hsGroup)
         -- TODO(robinpalotai): maybe add context. It would need first finding
         --   the context roots, and only then doing the traversal.
-        sigRefs = concatMap refsFromSignature (universeBi hsGroup)
+        sigRefs =
+          case hs_valds hsGroup of
+            ValBindsOut _ lsigs -> concatMap refsFromSignature lsigs
+            _ -> []
         refContext = Nothing
     in map (toTickReference ctx refContext declAlts) (typeRefs ++ sigRefs)
   where
@@ -389,8 +392,8 @@ refsFromRenamed ctx declAlts (hsGroup, _, _, _) =
         -- TODO(robinpalotai): HsTyLit for type literals.
         _ -> Nothing
 
-    refsFromSignature :: Sig Name -> [Reference]
-    refsFromSignature sig = case sig of
+    refsFromSignature :: LSig Name -> [Reference]
+    refsFromSignature (L _ sig) = case sig of
         TypeSig names _ _ ->
             mapMaybe (\(L l n) -> give ctx (nameLocToRef n TypeDecl l)) names
         _ -> []

--- a/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
+++ b/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
@@ -379,7 +379,8 @@ refsFromRenamed ctx declAlts (hsGroup, _, _, _) =
         sigRefs =
           case hs_valds hsGroup of
             ValBindsOut _ lsigs -> concatMap refsFromSignature lsigs
-            _ -> []
+            ValBindsIn _ lsigs ->
+              error "should not hit ValBindsIn when accessing renamed AST"
         refContext = Nothing
     in map (toTickReference ctx refContext declAlts) (typeRefs ++ sigRefs)
   where

--- a/haskell-indexer-frontend-kythe/src/Language/Haskell/Indexer/Frontend/Kythe.hs
+++ b/haskell-indexer-frontend-kythe/src/Language/Haskell/Indexer/Frontend/Kythe.hs
@@ -109,7 +109,12 @@ makeUsageFacts TickReference{..} = do
     --   anchor) and ref/call (with anchor spanning also the args).
     targetVname <- tickVName refTargetTick
     mbCallContext <- traverse tickVName refHighLevelContext
-    makeAnchor (Just refSourceSpan) RefE targetVname Nothing mbCallContext
+    let edgeType =
+          case refKind of
+            Ref -> RefE
+            Call -> RefE
+            TypeDecl -> RefDocE
+    makeAnchor (Just refSourceSpan) edgeType targetVname Nothing mbCallContext
 
 -- | Makes all entries for a declaration.
 makeDeclFacts :: Decl -> Conversion [Raw.Entry]

--- a/haskell-indexer-frontend-kythe/src/Language/Haskell/Indexer/Frontend/Kythe.hs
+++ b/haskell-indexer-frontend-kythe/src/Language/Haskell/Indexer/Frontend/Kythe.hs
@@ -109,8 +109,7 @@ makeUsageFacts TickReference{..} = do
     --   anchor) and ref/call (with anchor spanning also the args).
     targetVname <- tickVName refTargetTick
     mbCallContext <- traverse tickVName refHighLevelContext
-    let edgeType =
-          case refKind of
+    let edgeType = case refKind of
             Ref -> RefE
             Call -> RefE
             TypeDecl -> RefDocE

--- a/haskell-indexer-translate/src/Language/Haskell/Indexer/Translate.hs
+++ b/haskell-indexer-translate/src/Language/Haskell/Indexer/Translate.hs
@@ -205,7 +205,10 @@ data TickReference = TickReference
 -- argument application, the rest are reference. The frontend is free to
 -- disregard this information and treat everything as calls or references
 -- though.
-data ReferenceKind = Ref | Call
+data ReferenceKind
+    = Ref      -- ^ Reference
+    | Call     -- ^ Function call
+    | TypeDecl -- ^ Usage of identifier in type declaration, left to "::"
     deriving (Eq, Ord, Show)
 
 -- | Read it aloud as 'relSourceTick' 'relKind' 'relTargetTick'.

--- a/kythe-schema/src/Language/Kythe/Schema/Typed.hs
+++ b/kythe-schema/src/Language/Kythe/Schema/Typed.hs
@@ -171,6 +171,7 @@ data AnchorEdge
     | DefinesBindingE
     | RefE
     | RefCallE
+    | RefDocE
 
 printEdge :: Edge -> Text
 printEdge = \case
@@ -183,4 +184,5 @@ printEdge = \case
         DefinesBindingE -> "/kythe/edge/defines/binding"
         RefE            -> "/kythe/edge/ref"
         RefCallE        -> "/kythe/edge/ref/call"
+        RefDocE         -> "/kythe/edge/ref/doc"
 

--- a/kythe-verification/test.sh
+++ b/kythe-verification/test.sh
@@ -30,6 +30,7 @@ die() {
 
 for fut in \
     "$BASIC/Anchors.hs" \
+    "$BASIC/CrossRef1.hs $BASIC/CrossRef2.hs" \
     "$BASIC/DataRef.hs" \
     "$BASIC/FunctionArgRef.hs" \
     "$BASIC/LocalRef.hs" \
@@ -37,7 +38,6 @@ for fut in \
     "$BASIC/RecordWriteRef.hs" \
     "$BASIC/RecursiveRef.hs" \
     "$BASIC/TypeclassRef.hs" \
-    "$BASIC/CrossRef1.hs $BASIC/CrossRef2.hs" \
     "$BASIC/TypeDef.hs"
 
 do

--- a/kythe-verification/test.sh
+++ b/kythe-verification/test.sh
@@ -37,7 +37,9 @@ for fut in \
     "$BASIC/RecordWriteRef.hs" \
     "$BASIC/RecursiveRef.hs" \
     "$BASIC/TypeclassRef.hs" \
-    "$BASIC/CrossRef1.hs $BASIC/CrossRef2.hs"
+    "$BASIC/CrossRef1.hs $BASIC/CrossRef2.hs" \
+    "$BASIC/TypeDef.hs"
+
 do
   echo "Verifying: $fut"
   $GHC_KYTHE -- $fut 2> /dev/null | $VERIFIER -goal_prefix '-- -' $fut \

--- a/kythe-verification/testdata/basic/TypeDef.hs
+++ b/kythe-verification/testdata/basic/TypeDef.hs
@@ -1,0 +1,6 @@
+module TypeDef where
+
+-- - @add ref/doc FunAdd
+add :: Int -> Int -> Int
+-- - @add defines/binding FunAdd
+add x y = x + y


### PR DESCRIPTION
Fixes #20.

Not a final implementation, just opening a pull request to get some feedback early. One of the known problems is that `completes/uniquely` is not used at the moment.

New constructor in `ReferencedKind` is unused - it seems like the code in frontend does not pattern-match on values of this datatype at all (or at least I haven't found a place, and the code successfully compiles).