### PR TITLE
Split build-stack.sh into build-stack.sh (building) and serve.sh (run…

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,23 @@ pushd kythe-verification; stack install && ./test.sh; popd
 
 # Demo
 
-To index a few packages and serve the index, run:
+To index a few packages, run:
 
-```
+```bash
 ./build-stack.sh /tmp/logs mtlparse cpu
 ```
 
-The script temporarily replaces the system GHC with
-`wrappers/stack-docker/fake-stack/ghc` script, does the indexing and serves the
-built index at `localhost:8080`.
+The script adds a wrapper for the GHC compiler used by Stack (`stack path --compiler-exe`), does the indexing when `ghc --make` is specified on the command line to build a package. You can run `build-stack.sh` multiple times.
+
+To serve the index at `http://localhost:8080`:
+
+```bash
+./serve.sh /tmp/logs localhost:8080
+```
 
 If you get empty index, look at `/tmp/logs/*.stderr` files about possible
-indexing errors. Also make sure that you `/tmp/logs/*.entries` files are not
-empty. If they are, there was some trouble with indexing.
+indexing errors. Also make sure that your `/tmp/logs/*.entries` files are not
+empty. If they are, it indicates that `ghc_kythe_wrapper` failed to index.
 
 ## Indexing using Docker
 

--- a/build-stack.sh
+++ b/build-stack.sh
@@ -3,45 +3,35 @@
 # Script for building Kythe index of Haskell packages.
 # Usage: bash build-stack.sh /tmp/logs package...
 
-fail() {
-  (>&2 echo "$1")
+if (($# < 2)); then
+  echo "Usage: $0 /tmp/logs package..." >&2
   exit 1
-}
+fi
 
 # Directory where to build the index.
 export INDEXER_OUTPUT_DIR=$1
+mkdir -p "$INDEXER_OUTPUT_DIR"
 
 # REALGHC is used by stack wrapper ghc. Note that it must be set before
 # altering the PATH.
 export REALGHC=$(stack path --compiler-exe)
 
+project_root=$(cd "$(dirname "$0")"; pwd)
+
 # Build and index the packages
 # ============================
-# Put stack wrapper ghc script, ghc-pkg (from compiler-bin) and
-# ghc_kythe_wrapper (from local-install-root) on the PATH. Note that stack
-# wrapper ghc script replaces the system ghc.
-PATH=$PWD/wrappers/stack:$(stack path --compiler-bin):$PATH:$(stack path --local-install-root)/bin \
-  stack --system-ghc build --no-nix --force-dirty ${@:2}
-[[ $? != 0 ]] && fail "Indexing failed!"
-
-# Serve the index
-# ===============
-# It's probably more efficient to cat them together, but this way we see
-# if a given one is corrupted for any reason.
-for e in $(ls ${INDEXER_OUTPUT_DIR}/*entries)
-do
-  echo " * ${e}"
-  cat ${e} | /opt/kythe/tools/write_entries --graphstore ${INDEXER_OUTPUT_DIR}/gs
+# `stack build` does not rebuild packages if they have been registered in the
+# snapshot database (something like ~/.stack/snapshots/x86_64-linux/lts-8.17/8.0.2/pkgdb),
+# thus we unregister the packages first to force rebuilding.
+# Note: `ghc-pkg unregister` does not unregister dependencies, so dependencies
+# won't be reindexed unless explicitly specified in the command line.
+for i in "${@:2}"; do
+  stack exec -- ghc-pkg unregister --force "$i" || :
 done
-echo "== Converting to serving tables."
-/opt/kythe/tools/write_tables \
-    --graphstore ${INDEXER_OUTPUT_DIR}/gs \
-    --out ${INDEXER_OUTPUT_DIR}/tbl \
-    --compress_shards
-echo "== Starting HTTP server."
-echo " * Click the ::/ in it's top-left!"
-/opt/kythe/tools/http_server \
-    --serving_table ${INDEXER_OUTPUT_DIR}/tbl \
-    --listen 0.0.0.0:8080 \
-    --public_resources /opt/kythe/web/ui
-# The index is served at localhost:8080
+
+# Put stack wrapper ghc script, ghc-pkg (from compiler-bin) and
+# ghc_kythe_wrapper (from local-install-root, invoked by wrappers/stack/ghc) on the PATH.
+# $(stack path --compiler-bin) is also on the PATH to make --system-ghc pick it instead
+# of system ghc (e.g. /usr/bin/ghc).
+PATH="$project_root/wrappers/stack:$(stack path --compiler-bin):$PATH:$(stack path --local-install-root)/bin" \
+  stack --system-ghc build "${@:2}"

--- a/serve.sh
+++ b/serve.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+if (($# != 2)); then
+  echo "Usage: $0 /tmp/logs localhost:8080" >&2
+  exit 1
+fi
+
+INDEXER_OUTPUT_DIR=$1
+
+# Serve the index
+# ===============
+# Delete old Kythe GraphStore and Kythe serving tables.
+rm -fr "$INDEXER_OUTPUT_DIR"/{gs,tbl}
+
+# It's probably more efficient to cat them together, but this way we see
+# if a given one is corrupted for any reason.
+for e in "$INDEXER_OUTPUT_DIR"/*.entries
+do
+  echo " * ${e}"
+  /opt/kythe/tools/write_entries --graphstore "$INDEXER_OUTPUT_DIR/gs" < "$e"
+done
+echo "== Converting to serving tables."
+/opt/kythe/tools/write_tables \
+    --graphstore "$INDEXER_OUTPUT_DIR/gs" \
+    --out "$INDEXER_OUTPUT_DIR/tbl" \
+    --compress_shards
+echo "== Starting HTTP server."
+echo " * Click the ::/ in the top-left!"
+/opt/kythe/tools/http_server \
+    --serving_table "$INDEXER_OUTPUT_DIR/tbl" \
+    --listen "$2" \
+    --public_resources /opt/kythe/web/ui

--- a/wrappers/stack/ghc
+++ b/wrappers/stack/ghc
@@ -3,43 +3,27 @@
 # GHC wrapper for indexing Haskell packages.
 # Note that variables INDEXER_OUTPUT_DIR and REALGHC are set outside this script.
 
-if [[ "$INDEXER_OUTPUT_DIR" = "" ]]; then
-    echo "INDEXER_OUTPUT_DIR not set!"
-    exit -1
-fi
-
-if [[ "$REALGHC" = "" ]]; then
-    echo "REALGHC not set!"
-    exit -1
-fi
-
-PKG=$(basename "$(pwd)")
-
-mkdir -p "${INDEXER_OUTPUT_DIR}"
 log() {
-    echo "$1" >> ${INDEXER_OUTPUT_DIR}/${PKG}.log
+    echo "$1" >> "$INDEXER_OUTPUT_DIR/$PKG.log"
 }
 
 log "========= FAKE GHC ======="
-log " == pwd: $(pwd)"
-for arg in $@
-do
-  if [[ "${arg}" == "-static" ]]; then
-    STATIC="true"
-  fi
-  log "ARG: ${arg}"
-done
+log " == pwd: $PWD"
 log "== Passing through.."
 log "$REALGHC $*"
 $REALGHC "$@"
 RESULT=$?
-if [[ "$STATIC" = "true" ]]; then
+# $(stack path --compiler_exe) is invoked by `stack build` multiple times,
+# we are only interested when `--make` is specified.
+if [[ "${@#--make}" != "$@" ]]; then
+  PKG=${PWD##*/}
   log "== Invoking indexer"
-  ghc_kythe_wrapper \
+  if ! ghc_kythe_wrapper \
     --drop_path_prefix './' \
-    --prepend_path_prefix "${PKG}/" \
+    --prepend_path_prefix "$PKG/" \
     -- \
-    "$@" >> ${INDEXER_OUTPUT_DIR}/${PKG}.entries 2> ${INDEXER_OUTPUT_DIR}/${PKG}.stderr
-  [[ "$?" != "0" ]] && echo "${PKG} had error" >> ${INDEXER_OUTPUT_DIR}/errors
+    "$@" > "$INDEXER_OUTPUT_DIR/$PKG.entries" 2> "$INDEXER_OUTPUT_DIR/$PKG.stderr"; then
+    echo "$PKG had error" >> "$INDEXER_OUTPUT_DIR/errors"
+  fi
 fi
 exit $RESULT


### PR DESCRIPTION
…ning http server, and refactor the `$compiler_exec` hooking mechanism.

The current command line `stack --system-ghc build --no-nix --force-dirty` does not rebuild packages. Use `stack exec -- ghc-pkg unregister --force` to force rebuilding and therefore reindexing.
Also switch from system ghc to stack ghc.

In wrappers/stack/ghc_post_hook (was: wrappers/stack/ghc), I suppose `--make` makes more sense than `-static`.