### PR TITLE
Travis: use --install-ghc for now even for Cabal when using Stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,7 +133,8 @@ install:
       travis_retry cabal update
 
       # Get the list of packages from the stack.yaml file
-      PACKAGES=$(stack --system-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
+      # See https://github.com/commercialhaskell/stack/issues/3238
+      PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
 
       cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
       ;;


### PR DESCRIPTION
Due to potential version mismatch - stack will complain if the actual GHC is not according to the resolver.