### PR TITLE
Add references for pragmas

### DIFF
--- a/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
+++ b/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
@@ -33,6 +33,7 @@ import qualified Bag as GHC
 import qualified BasicTypes as GHC
 import qualified DataCon as GHC
 import qualified Name as GHC
+import BooleanFormula
 import FastString (unpackFS)
 import GHC
 import qualified Id as GHC
@@ -506,7 +507,29 @@ refsFromRenamed ctx declAlts (hsGroup, _, _, _) =
         TypeSig names _ _ ->
 #endif
             mapMaybe (\(L l n) -> give ctx (nameLocToRef n TypeDecl l)) names
+        (PatSynSig lnames _) ->
+          lkupSigNames [lnames]
+        (FixSig (FixitySig lnames _)) ->
+          lkupSigNames lnames
+        (InlineSig lname _) -> lkupSigNames [lname]
+        (SpecSig lname ltypes _) -> lkupSigNames [lname]
+        (SpecInstSig st lst) -> []
+        (MinimalSig st lbf) -> lkupSigNames (namesFromLBooleanFormula lbf)
         _ -> []
+      where
+        lkupSigNames names =
+          mapMaybe (\(L l n) -> give ctx (nameLocToRef n Ref l)) names
+
+namesFromBooleanFormula :: BooleanFormula a -> [a]
+namesFromBooleanFormula bf =
+  case bf of
+    Var a -> [a]
+    And lbfs -> concatMap namesFromLBooleanFormula lbfs
+    Or lbfs -> concatMap namesFromLBooleanFormula lbfs
+    Parens lbf -> namesFromLBooleanFormula lbf
+
+namesFromLBooleanFormula :: LBooleanFormula a -> [a]
+namesFromLBooleanFormula (L _ bf) = namesFromBooleanFormula bf
 
 -- | Exports subclasses/overrides relationships from typeclasses.
 relationsFromRenamed :: ExtractCtx -> DeclAltMap -> RenamedSource


### PR DESCRIPTION
This patch adds reference for things like `INLINE` pragmas.

I tested it by running the indexer on `lens` and observing that the `INLINE` pragmas are now linked as expected. 