### PR TITLE
Use absolute path for log location

### DIFF
--- a/serve.sh
+++ b/serve.sh
@@ -4,7 +4,7 @@ if (($# != 2)); then
   exit 1
 fi
 
-INDEXER_OUTPUT_DIR=$1
+INDEXER_OUTPUT_DIR=$(readlink -m $1)
 
 # Serve the index
 # ===============


### PR DESCRIPTION
If you try to use a relative path then the log files get put in strange locations as cabal changes directory when building packages. 