### PR TITLE
Revert "Work around issue with old (<2.0) cabal versions and the hack…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,12 +109,9 @@ before_install:
     unzip -j protoc-*-linux-x86_64.zip bin/protoc -d ~/.local/bin
   fi
 
-  # Temporary use normal hackage, as it might have cabal workarounds, see
-  # https://github.com/haskell/cabal/issues/4624#issuecomment-318743713.
   # Use the more reliable S3 mirror of Hackage
   mkdir -p $HOME/.cabal
-  # echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
-  echo 'remote-repo: hackage.haskell.org:http://hackage.haskell.org/' > $HOME/.cabal/config
+  echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
   echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
 
   if [ "$CABALVER" != "1.16" ]


### PR DESCRIPTION
…age index."

This reverts commit 2b356bf3248ea49a2d000ddfd36365ed58bf2479, since the
issue should have been fixed.