### PR TITLE
Make the module name bind the Kythe package instead just referencing it.

### DIFF
--- a/haskell-indexer-frontend-kythe/src/Language/Haskell/Indexer/Frontend/Kythe.hs
+++ b/haskell-indexer-frontend-kythe/src/Language/Haskell/Indexer/Frontend/Kythe.hs
@@ -71,9 +71,8 @@ toKythe basevn content XRef{..} = do
         pkgFileEntry = edge filevn ChildOfE pkgvn
     sourceList (pkgFileEntry : pkgEntries ++ fileEntries)
     flip runReaderT env $ do
-        -- Note: Kythe schema doesn't do 'define/binding' on package which
-        -- makes sense generally. So we don't do so either from Haskell.
-        stream (makeAnchor (mtSpan xrefModule) RefE pkgvn Nothing Nothing)
+        stream (makeAnchor (mtSpan xrefModule) DefinesBindingE pkgvn
+                           Nothing Nothing)
         mapM_ (stream . makeDeclFacts) xrefDecls
         mapM_ (stream . makeUsageFacts) xrefCrossRefs
         mapM_ (stream . makeRelationFacts) xrefRelations

--- a/kythe-verification/testdata/basic/CrossRef1.hs
+++ b/kythe-verification/testdata/basic/CrossRef1.hs
@@ -1,3 +1,4 @@
+-- - @"CrossRef1" defines/binding vname("main_main:CrossRef1", "", "", "", "haskell")
 module CrossRef1 (foo) where
 
 foo :: Int

--- a/kythe-verification/testdata/basic/Module.hs
+++ b/kythe-verification/testdata/basic/Module.hs
@@ -1,5 +1,5 @@
 -- Haskell package+module combination corresponds to Kythe package.
--- - @Module ref Pkg
+-- - @Module defines/binding Pkg
 -- - Pkg.node/kind package
 module Module where
 


### PR DESCRIPTION
Never trust your own comments. Of course the module name needs defines/binding if we want to jump to it. That's what the Go schema does by the way too.

Issue: #6 

@ivan444 please review.