### PR TITLE
Add LTS snapshot for GHC 8.2.2 + Cabal 2.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,10 @@ matrix:
     compiler: ": #GHC 8.0.2"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
+  - env: BUILD=cabal GHCVER=8.2.2 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.2.2"
+    addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+
   # Build with the newest GHC and cabal-install. This is an accepted failure,
   # see below.
   - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
@@ -70,8 +74,8 @@ matrix:
     compiler: ": #stack lts-8 (GHC 8.0.2)"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver nightly-2017-08-25"
-    compiler: ": #stack nightly (GHC 8.2.1)"
+  - env: BUILD=stack ARGS="--resolver lts-10"
+    compiler: ": #stack lts-10 (GHC 8.2.2)"
     addons: {apt: {packages: [libgmp-dev]}}
 
   # Nightly builds are allowed to fail

--- a/haskell-indexer-backend-core/haskell-indexer-backend-core.cabal
+++ b/haskell-indexer-backend-core/haskell-indexer-backend-core.cabal
@@ -1,7 +1,7 @@
 name:                haskell-indexer-backend-core
 version:             0.1.0.0
 synopsis:            Code common to all indexer backends.
-description:         See README.md.
+description:         Part of haskell-indexer, see top-level README.md for more info.
 homepage:            https://github.com/google/haskell-indexer
 license:             Apache-2.0
 license-file:        LICENSE

--- a/haskell-indexer-backend-ghc/haskell-indexer-backend-ghc.cabal
+++ b/haskell-indexer-backend-ghc/haskell-indexer-backend-ghc.cabal
@@ -1,7 +1,7 @@
 name:                haskell-indexer-backend-ghc
 version:             0.1.0.0
 synopsis:            Indexing code using GHC API.
-description:         See README.md.
+description:         Part of haskell-indexer, see top-level README.md for more info.
 homepage:            https://github.com/google/haskell-indexer
 license:             Apache-2.0
 license-file:        LICENSE

--- a/haskell-indexer-frontend-kythe/haskell-indexer-frontend-kythe.cabal
+++ b/haskell-indexer-frontend-kythe/haskell-indexer-frontend-kythe.cabal
@@ -1,7 +1,7 @@
 name:                haskell-indexer-frontend-kythe
 version:             0.1.0.0
 synopsis:            Emits Kythe schema based on translation layer data.
-description:         See README.md.
+description:         Part of haskell-indexer, see top-level README.md for more info.
 homepage:            https://github.com/google/haskell-indexer
 license:             Apache-2.0
 license-file:        LICENSE

--- a/haskell-indexer-pathutil/haskell-indexer-pathutil.cabal
+++ b/haskell-indexer-pathutil/haskell-indexer-pathutil.cabal
@@ -1,7 +1,7 @@
 name:                haskell-indexer-pathutil
 version:             0.1.0.0
 synopsis:            Utilities for dealing with filepaths.
-description:         See README.md.
+description:         Part of haskell-indexer, see top-level README.md.
 homepage:            https://github.com/google/haskell-indexer
 license:             Apache-2.0
 license-file:        LICENSE

--- a/haskell-indexer-pipeline-ghckythe-wrapper/haskell-indexer-pipeline-ghckythe-wrapper.cabal
+++ b/haskell-indexer-pipeline-ghckythe-wrapper/haskell-indexer-pipeline-ghckythe-wrapper.cabal
@@ -1,7 +1,8 @@
 name:                haskell-indexer-pipeline-ghckythe-wrapper
 version:             0.1.0.0
 synopsis:            Executable able to take GHC arguments and emitting Kythe entries.
-description:         See README.md.
+description:         Part of haskell-indexer, see top-level README.md for more info.
+                     Should be merged into ghckythe eventually.
 homepage:            https://github.com/google/haskell-indexer
 license:             Apache-2.0
 license-file:        LICENSE

--- a/haskell-indexer-pipeline-ghckythe/haskell-indexer-pipeline-ghckythe.cabal
+++ b/haskell-indexer-pipeline-ghckythe/haskell-indexer-pipeline-ghckythe.cabal
@@ -1,7 +1,7 @@
 name:                haskell-indexer-pipeline-ghckythe
 version:             0.1.0.0
 synopsis:            Gets GHC invocation arguments and streams Kythe entries.
-description:         See README.md.
+description:         Part of haskell-indexer, see top-level README.md for more info.
 homepage:            https://github.com/google/haskell-indexer
 license:             Apache-2.0
 license-file:        LICENSE

--- a/haskell-indexer-translate/haskell-indexer-translate.cabal
+++ b/haskell-indexer-translate/haskell-indexer-translate.cabal
@@ -1,7 +1,7 @@
 name:                haskell-indexer-translate
 version:             0.1.0.0
 synopsis:            Translation layer isolating compiler backends from frontends.
-description:         See README.md.
+description:         Part of haskell-indexer, see top-level README.md for more info.
 homepage:            https://github.com/google/haskell-indexer
 license:             Apache-2.0
 license-file:        LICENSE

--- a/kythe-proto/kythe-proto.cabal
+++ b/kythe-proto/kythe-proto.cabal
@@ -1,7 +1,7 @@
 name:                kythe-proto
 version:             0.1.0.0
 synopsis:            Proto bindings for Kythe protobufs.
-description:         See README.md.
+description:         Part of haskell-indexer, see top-level README.md for more info.
 homepage:            https://github.com/google/haskell-indexer
 license:             Apache-2.0
 license-file:        LICENSE

--- a/kythe-schema/kythe-schema.cabal
+++ b/kythe-schema/kythe-schema.cabal
@@ -1,7 +1,7 @@
 name:                kythe-schema
 version:             0.1.0.0
 synopsis:            Library for emitting Kythe schema entries.
-description:         See README.md.
+description:         Part of haskell-indexer, see top-level README.md for more info.
 homepage:            https://github.com/google/haskell-indexer
 license:             Apache-2.0
 license-file:        LICENSE

--- a/stack-6.30.yaml
+++ b/stack-6.30.yaml
@@ -2,7 +2,7 @@
 # docker image. See below why is that useful. If you are not interested in
 # doing a full-stackage index based on docker snapshot, feel free to use
 # other version.
-resolver: lts-6.30
+resolver: lts-6.30  # GHC 7.10.3
 
 packages:
 - haskell-indexer-backend-core

--- a/stack-lts-10.0.yaml
+++ b/stack-lts-10.0.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2017-08-25
+resolver: lts-10.0  # GHC 8.2.2
 
 packages:
 - haskell-indexer-backend-core

--- a/stack-lts-9.2.yaml
+++ b/stack-lts-9.2.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.2
+resolver: lts-9.2  # GHC 8.0.2
 
 packages:
 - haskell-indexer-backend-core

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.17
+resolver: lts-8.17  # GHC 8.0.2
 
 packages:
 - haskell-indexer-backend-core
@@ -20,3 +20,4 @@ explicit-setup-deps:
 
 nix:
   packages: [gcc, protobuf3_2]
+


### PR DESCRIPTION
Cabal descriptions update to make cabal check happy.