### PR TITLE
A narrower version range for proto-lens.

### DIFF
--- a/haskell-indexer-pipeline-ghckythe-wrapper/haskell-indexer-pipeline-ghckythe-wrapper.cabal
+++ b/haskell-indexer-pipeline-ghckythe-wrapper/haskell-indexer-pipeline-ghckythe-wrapper.cabal
@@ -24,7 +24,7 @@ library
                      , haskell-indexer-translate >= 0.1
                      , kythe-schema >= 0.1
                      , optparse-applicative
-                     , proto-lens
+                     , proto-lens >= 0.4 && < 0.5
                      , text
   exposed-modules:  Language.Haskell.Indexer.Args
   default-language: Haskell2010

--- a/kythe-proto/kythe-proto.cabal
+++ b/kythe-proto/kythe-proto.cabal
@@ -19,10 +19,10 @@ library
   autogen-modules:     Proto.Kythe.Proto.Storage
                      , Proto.Kythe.Proto.Storage_Fields
   build-depends:       base >=4.8 && <5
-                     , proto-lens-runtime >= 0.4
+                     , proto-lens-runtime >= 0.4 && < 0.5
   default-language:    Haskell2010
 
 custom-setup
   setup-depends:       base >=4.8 && <5
                      , Cabal
-                     , proto-lens-setup >= 0.4
+                     , proto-lens-setup >= 0.4 && < 0.5

--- a/kythe-proto/kythe-proto.cabal
+++ b/kythe-proto/kythe-proto.cabal
@@ -26,4 +26,4 @@ custom-setup
   setup-depends:       base >=4.8 && <5
                      , Cabal
                      , proto-lens-protoc >= 0.4 && < 0.5
-                     , proto-lens-setup >= 0.4 && < 0.5
+                     , proto-lens-setup == 0.4.0.1

--- a/kythe-proto/kythe-proto.cabal
+++ b/kythe-proto/kythe-proto.cabal
@@ -25,4 +25,5 @@ library
 custom-setup
   setup-depends:       base >=4.8 && <5
                      , Cabal
+                     , proto-lens-protoc >= 0.4 && < 0.5
                      , proto-lens-setup >= 0.4 && < 0.5

--- a/kythe-schema/kythe-schema.cabal
+++ b/kythe-schema/kythe-schema.cabal
@@ -23,7 +23,7 @@ library
                      , data-default
                      , kythe-proto
                      , lens-family
-                     , proto-lens >= 0.4
+                     , proto-lens >= 0.4 && < 0.5
                      , proto-lens-combinators == 0.4.*
                      , text
   default-language:    Haskell2010


### PR DESCRIPTION
Without this, cabal builds fail when proto-lens 0.5 is used together
with proto-lens-runtime 0.4.