### PR TITLE
Support xrefs for imported entities.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.swp
 .projectile
 **/dist
+*.yaml.lock

--- a/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Compat.hs
+++ b/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Compat.hs
@@ -413,6 +413,9 @@ pattern ClsInstDeclCompat lty lbinds  <-
   ClsInstDecl _ lty lbinds _ _ _ _
 #endif
 
-
-
-
+pattern IEVarCompat lwn <-
+#if __GLASGOW_HASKELL__ < 806
+  IEVar lwn
+#else
+  IEVar _ lwn
+#endif

--- a/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Compat.hs
+++ b/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Compat.hs
@@ -419,3 +419,8 @@ pattern IEVarCompat lwn <-
 #else
   IEVar _ lwn
 #endif
+
+-- 8.0.x doesn't have ieWrappedName.
+#if __GLASGOW_HASKELL__ < 802
+ieWrappedName = id
+#endif

--- a/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
+++ b/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
@@ -467,7 +467,7 @@ refsFromRenamed ctx declAlts (hsGroup, importDecls, _, _) =
       _ -> []
 
     refsFromImport :: LIE GhcRn -> Maybe Reference
-    refsFromImport (L _ (IEVar _ (L l n))) =
+    refsFromImport (L _ (IEVarCompat (L l n))) =
         give ctx (nameLocToRef (ieWrappedName n) Ref l)
     refsFromImport _ = Nothing
 

--- a/haskell-indexer-backend-ghc/testdata/basic/ImportDefs.hs
+++ b/haskell-indexer-backend-ghc/testdata/basic/ImportDefs.hs
@@ -1,0 +1,7 @@
+module ImportDefs (foo, bar) where
+
+foo :: Int
+foo = 42
+
+bar :: Double
+bar = 42.0

--- a/haskell-indexer-backend-ghc/testdata/basic/ImportDefs.hs
+++ b/haskell-indexer-backend-ghc/testdata/basic/ImportDefs.hs
@@ -1,7 +1,18 @@
-module ImportDefs (foo, bar) where
+module ImportDefs
+  ( FooBar (..),
+    bar,
+    foo,
+  )
+where
 
 foo :: Int
 foo = 42
 
 bar :: Double
 bar = 42.0
+
+data FooBar
+  = FooBar
+      { fbFoo :: Int,
+        fbBar :: Double
+      }

--- a/haskell-indexer-backend-ghc/testdata/basic/ImportRefs.hs
+++ b/haskell-indexer-backend-ghc/testdata/basic/ImportRefs.hs
@@ -1,3 +1,3 @@
 module ImportRefs where
 
-import ImportDefs (foo, bar)
+import ImportDefs (FooBar (..), bar, foo)

--- a/haskell-indexer-backend-ghc/testdata/basic/ImportRefs.hs
+++ b/haskell-indexer-backend-ghc/testdata/basic/ImportRefs.hs
@@ -1,0 +1,3 @@
+module ImportRefs where
+
+import ImportDefs (foo, bar)

--- a/haskell-indexer-backend-ghc/testdata/basic/ImportRefsHiding.hs
+++ b/haskell-indexer-backend-ghc/testdata/basic/ImportRefsHiding.hs
@@ -1,0 +1,3 @@
+module ImportRefsHiding where
+
+import ImportDefs hiding (bar)

--- a/haskell-indexer-backend-ghc/tests/Language/Haskell/Indexer/Backend/Ghc/Test/BasicTestBase.hs
+++ b/haskell-indexer-backend-ghc/tests/Language/Haskell/Indexer/Backend/Ghc/Test/BasicTestBase.hs
@@ -16,7 +16,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Language.Haskell.Indexer.Backend.Ghc.Test.BasicTestBase (allTests) where
 
-import Control.Monad ((>=>), void)
+import Control.Monad ((>=>), unless, void)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT)
 
 import Language.Haskell.Indexer.Backend.Ghc.Test.TestHelper
@@ -330,20 +330,41 @@ testImports = assertXRefsFrom ["basic/Imports.hs"] $ do
     importAt (3, 8) "Data.Int"
     importAt (4, 8) "Data.List"
 
+assertRefKind :: ReferenceKind -> TickReference -> ReaderT XRef IO ()
+assertRefKind expected tick =
+  let actual = refKind tick
+   in unless (actual == expected)
+        $ checking
+        $ assertFailure
+        $ show expected ++ " expected; got " ++ show actual
+
 testImportRefs :: AssertionInEnv
 testImportRefs = assertXRefsFrom ["basic/ImportDefs.hs", "basic/ImportRefs.hs"]
   $ do
     -- foo
-    declAt (4,1) >>= usages >>= \case
-        [u1, u2] -> do
-            includesPos (3,1) u1  -- type signature in ImportDefs.hs
-            includesPos (3,20) u2 -- import statement in ImportRefs.hs
-        us -> checking $ assertFailure "Usage count differs for foo"
+    declAt (9, 1) >>= usages >>= \case
+      [u1, u2] -> do
+        includesPos (3, 38) u1 -- import statement in ImportRefs.hs
+        assertRefKind Import u1
+        includesPos (8, 1) u2 -- type signature in ImportDefs.hs
+      us -> checking $ assertFailure "Usage count differs for foo"
     -- bar
-    declAt (7,1) >>= usages >>= \case
+    declAt (12, 1) >>= usages >>= \case
+      [u1, u2] -> do
+        includesPos (3, 33) u1 -- import statement in ImportRefs.hs
+        assertRefKind Import u1
+        includesPos (11, 1) u2 -- type signature in ImportDefs.hs
+      us -> checking $ assertFailure "Usage count differs for bar"
+
+testImportRefsHiding :: AssertionInEnv
+testImportRefsHiding =
+  assertXRefsFrom ["basic/ImportDefs.hs", "basic/ImportRefsHiding.hs"]
+    $ do
+      declAt (12, 1) >>= usages >>= \case
         [u1, u2] -> do
-            includesPos (3,25) u1 -- import statement in ImportRefs.hs
-            includesPos (6,1) u2  -- type signature in ImportDefs.hs
+          includesPos (3, 27) u1 -- import statement in ImportRefsHiding.hs
+          assertRefKind Ref u1
+          includesPos (11, 1) u2 -- type signature in ImportDefs.hs
         us -> checking $ assertFailure "Usage count differs for bar"
 
 -- | Prepares the tests to run with the given test environment.
@@ -371,7 +392,8 @@ allTests env =
     , envTestCase "data-con-wrap" testDataConWrap
     , envTestCase "utf8" testUtf8
     , envTestCase "imports" testImports
-    , envTestCase "importRefs" testImportRefs
+    , envTestCase "import-refs" testImportRefs
+    , envTestCase "import-refs-hiding" testImportRefsHiding
     ]
   where
     envTestCase name test = testCase name (runReaderT test env)

--- a/haskell-indexer-backend-ghc/tests/Language/Haskell/Indexer/Backend/Ghc/Test/BasicTestBase.hs
+++ b/haskell-indexer-backend-ghc/tests/Language/Haskell/Indexer/Backend/Ghc/Test/BasicTestBase.hs
@@ -25,11 +25,6 @@ import Test.Framework (Test)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.HUnit (assertFailure)
 
-import Control.Monad.IO.Class
-import Control.Monad.Trans.Reader
-
-import Control.Monad (forM_)
-
 type AssertionInEnv = ReaderT TestEnv IO ()
 
 -- | Tests that arguments of top-level functions, and their references, are

--- a/haskell-indexer-frontend-kythe/src/Language/Haskell/Indexer/Frontend/Kythe.hs
+++ b/haskell-indexer-frontend-kythe/src/Language/Haskell/Indexer/Frontend/Kythe.hs
@@ -129,6 +129,7 @@ makeUsageFacts TickReference{..} = do
             Ref -> RefE
             Call -> RefE
             TypeDecl -> RefDocE
+            Import -> RefImportsE
     makeAnchor (Just refSourceSpan) edgeType targetVname Nothing mbCallContext
 
 -- | Makes all entries for a declaration.

--- a/haskell-indexer-translate/src/Language/Haskell/Indexer/Translate.hs
+++ b/haskell-indexer-translate/src/Language/Haskell/Indexer/Translate.hs
@@ -223,6 +223,7 @@ data ReferenceKind
     = Ref      -- ^ Reference
     | Call     -- ^ Function call
     | TypeDecl -- ^ Usage of identifier in type declaration, left to "::"
+    | Import   -- ^ Imported entities
     deriving (Eq, Ord, Show)
 
 -- | A Relation is between standalone semantic nodes, in contrast to

--- a/kythe-verification/test.sh
+++ b/kythe-verification/test.sh
@@ -45,6 +45,7 @@ for fut in \
     "$BASIC/CrossRef1.hs $BASIC/CrossRef2.hs" \
     "$BASIC/DataRef.hs" \
     "$BASIC/FunctionArgRef.hs" \
+    "$BASIC/ImportDefs.hs $BASIC/ImportRefs.hs" \
     "$BASIC/LocalRef.hs" \
     "$BASIC/Module.hs" \
     "$BASIC/RecordReadRef.hs" \

--- a/kythe-verification/testdata/basic/DataRef.hs
+++ b/kythe-verification/testdata/basic/DataRef.hs
@@ -22,7 +22,7 @@ f (B x) =
     -- - @x ref PatternX
     x
 
--- @Record defines/binding TypeR
+-- - @Record defines/binding TypeR
 data Record =
     -- TODO(robinpalotai): - CtorR childof TypeR
     -- TODO(robinpalotai): - FieldR childof CtorR

--- a/kythe-verification/testdata/basic/ImportDefs.hs
+++ b/kythe-verification/testdata/basic/ImportDefs.hs
@@ -1,0 +1,20 @@
+module ImportDefs
+  ( FooBar (..),
+    bar,
+    foo,
+  )
+where
+
+foo :: Int
+-- - @foo defines/binding FooVar
+foo = 42
+
+bar :: Double
+-- - @bar defines/binding BarVar
+bar = 42.0
+
+data FooBar
+  = FooBar
+      { fbFoo :: Int,
+        fbBar :: Double
+      }

--- a/kythe-verification/testdata/basic/ImportRefs.hs
+++ b/kythe-verification/testdata/basic/ImportRefs.hs
@@ -1,0 +1,6 @@
+module ImportRefs where
+
+-- - @foo ref/imports FooVar
+import ImportDefs (foo)
+-- - @bar ref BarVar
+import ImportDefs hiding (bar)

--- a/kythe-verification/testdata/basic/RecordReadRef.hs
+++ b/kythe-verification/testdata/basic/RecordReadRef.hs
@@ -9,6 +9,7 @@ module RecordReadRef where
 --   alternative span).
 -- - @foo defines/binding FieldFoo
 -- - @bar defines/binding FieldBar
+-- - @#1Rec defines/binding CtorR
 data Rec = Rec { foo :: Int, bar :: Int }
 
 -- No field references here, only to the introduced local binding (see
@@ -38,7 +39,7 @@ punned Rec{foo} =
 -- - @foo ref FieldFoo
 -- - @baz defines/binding VarBaz
 reassigned Rec{foo=baz} =
-    -- @baz ref VarBaz
+    -- - @baz ref VarBaz
     baz
 
 -- - @bar ref FieldBar


### PR DESCRIPTION
This fixes https://github.com/google/haskell-indexer/issues/6.