### PR TITLE
Fix build warnings.

### DIFF
--- a/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Compat.hs
+++ b/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Compat.hs
@@ -20,6 +20,11 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 
+-- Maintaining cross-version-compatible signatures is hard for the
+-- compatibility layer.
+{-# OPTIONS_GHC -fno-warn-missing-pattern-synonym-signatures #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+
 -- | Module trying to expose a unified (or at least simplified) view of the GHC
 -- AST changes across multiple compiler versions.
 module Language.Haskell.Indexer.Backend.Compat where
@@ -30,13 +35,18 @@ import Control.Arrow ((&&&))
 import HsExtension
 #endif
 
-import CmdLineParser
+#if __GLASGOW_HASKELL__ >= 804
+import CmdLineParser (Warn, warnMsg)
+#endif
 
 #if __GLASGOW_HASKELL__ >= 800
 import Module (UnitId, unitIdString)
-import qualified Bag
 #else
 import Module (Module, packageKeyString, modulePackageKey)
+#endif
+
+#if __GLASGOW_HASKELL__ >= 800 && __GLASGOW_HASKELL__ < 804
+import qualified Bag
 #endif
 
 #if __GLASGOW_HASKELL__ < 802
@@ -45,7 +55,7 @@ import HsDecls (hs_instds)
 
 #if __GLASGOW_HASKELL__ < 800
 import GHC (PackageKey)
-import SrcLoc (combineSrcSpans)
+import SrcLoc (combineSrcSpans, getLoc)
 #endif
 
 import HsBinds (HsBindLR(..), Sig(..), LHsBinds, abe_mono, abe_poly)
@@ -55,12 +65,13 @@ import qualified HsTypes
 import HsTypes (HsType(HsTyVar), LHsType)
 import Id (Id)
 import Name (Name)
-import RdrName (RdrName)
 import Outputable (Outputable)
-import SrcLoc (Located, GenLocated(L), unLoc, getLoc)
+import SrcLoc (Located, GenLocated(L), unLoc)
 import GHC
 
 #if __GLASGOW_HASKELL__ < 804
+import RdrName (RdrName)
+
 type GhcPs = RdrName
 type GhcRn = Name
 type GhcTc = Id
@@ -196,6 +207,7 @@ pattern ClassDeclCompat locName binders sigs <-
 #if __GLASGOW_HASKELL__ >= 806
 conDeclNames (ConDeclH98 { con_name = conName })  = [conName]
 conDeclNames (ConDeclGADT { con_names = conNames }) = conNames
+conDeclNames (XConDecl _) = error "unexpected XConDecl"
 #elif __GLASGOW_HASKELL__ >= 800
 conDeclNames (ConDeclH98 conName _ _ _ _) = [conName]
 conDeclNames (ConDeclGADT conNames _ _) = conNames
@@ -213,11 +225,11 @@ maybeAbsBinds :: HsBindLR a b
 maybeAbsBinds :: HsBindLR a b
               -> Maybe (LHsBinds a, [(a, Maybe a)], AbsBindsKind)
 #endif
-maybeAbsBinds abs@(AbsBinds { abs_exports = exports,  abs_binds = binds}) =
+maybeAbsBinds absBinds@(AbsBinds { abs_exports = exports,  abs_binds = binds}) =
     let ids = map (abe_poly &&& (Just . abe_mono)) exports
         binds_type =
 #if __GLASGOW_HASKELL__ >= 804
-          if abs_sig abs then SigAbs else NormalAbs
+          if abs_sig absBinds then SigAbs else NormalAbs
 #else
           NormalAbs
 #endif
@@ -299,15 +311,15 @@ needsTemplateHaskellOrQQ = needsTemplateHaskell
 mgModSummaries = id
 #endif
 
+{-# COMPLETE ValBindsCompat #-}
 #if __GLASGOW_HASKELL__ < 806
 valBinds valds =
   case valds of
     ValBindsOut _ lsigs -> lsigs
-    ValBindsIn _ lsigs ->
+    ValBindsIn _ _lsigs ->
       error "should not hit ValBindsIn when accessing renamed AST"
 
-
-pattern ValBindsCompat  lsigs <- (valBinds -> lsigs)
+pattern ValBindsCompat lsigs <- (valBinds -> lsigs)
 #else
 pattern ValBindsCompat lsigs <- XValBindsLR (NValBinds _ lsigs)
 #endif
@@ -318,6 +330,7 @@ pattern HsForAllTyCompat binders <- HsForAllTy binders _
 pattern HsForAllTyCompat binders <- HsForAllTy _ binders _
 #endif
 
+{-# COMPLETE UserTyVarCompat, KindedTyVarCompat #-}
 #if __GLASGOW_HASKELL__ < 806
 pattern UserTyVarCompat n <- UserTyVar n
 pattern KindedTyVarCompat n <- KindedTyVar n _

--- a/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
+++ b/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
@@ -313,8 +313,7 @@ declsFromRenamed ctx (hsGroup, _, _, _) =
         mkDecl n = nameDeclAlt ctx n Nothing typeStringyType
     hsTyVarBinderName :: HsTyVarBndr id -> IdP id
     hsTyVarBinderName = \case
-        UserTyVarCompat n -> mayUnLoc n
-        KindedTyVarCompat n -> mayUnLoc n
+        HsTyVarBndrCompat n -> mayUnLoc n
     -- Datatypes.
     dataDecls :: LTyClDecl GhcRn -> [DeclAndAlt]
     dataDecls (L _ (DataDeclCompat locName binders defn)) =

--- a/haskell-indexer-frontend-kythe/src/Language/Haskell/Indexer/Frontend/Kythe.hs
+++ b/haskell-indexer-frontend-kythe/src/Language/Haskell/Indexer/Frontend/Kythe.hs
@@ -26,7 +26,7 @@ import Control.Monad.Morph (lift, hoist)
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Reader
 import qualified Data.ByteString as BS
-import Data.Conduit (ConduitM, Source)
+import Data.Conduit (ConduitT)
 import Data.Conduit.List (sourceList)
 import Data.Maybe (fromMaybe, maybeToList)
 import Data.Monoid ((<>))
@@ -58,7 +58,7 @@ type ConversionT = ReaderT ConversionEnv
 
 -- | Converts crossreference data of a file to Kythe schema.
 -- 'basevn' should have the corpus and language prefilled.
-toKythe :: Raw.VName -> T.Text -> XRef -> Source Identity Raw.Entry
+toKythe :: Raw.VName -> T.Text -> XRef -> ConduitT () Raw.Entry Identity ()
 toKythe basevn content XRef{..} = do
     let NameAndEntries pkgvn pkgEntries =
             makePackageFacts basevn (mtPkgModule xrefModule)
@@ -85,7 +85,7 @@ toKythe basevn content XRef{..} = do
 -- those entries. To be applied at reasonable points in the computation tree,
 -- where already a decent but not too large amount of entries have accumulated
 stream :: Conversion [Raw.Entry]
-       -> ConversionT (ConduitM () Raw.Entry Identity) ()
+       -> ConversionT (ConduitT () Raw.Entry Identity) ()
 stream a = do
     es <- hoist lift a
     lift (sourceList es)


### PR DESCRIPTION
It turns out quite painful to add pattern/function signatures to Compat.hs while making them compatible across multiple GHC versions. Just disable warnings in that file.

This addresses https://github.com/google/haskell-indexer/issues/99.