### PR TITLE
Bypass GHC errors to the caller.

### DIFF
--- a/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/GhcApiSupport.hs
+++ b/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/GhcApiSupport.hs
@@ -89,7 +89,7 @@ showSDocForUserOneLine dflags unqual doc =
 withTypechecked
     :: MVar () -> GhcArgs -> AnalysisOptions -> (XRef -> IO ()) -> IO ()
 withTypechecked globalLock GhcArgs{..} analysisOpts xrefSink
-        = withMVar globalLock . const . errHandling $ do
+        = withMVar globalLock . const $ do
     -- TODO(robinpalotai): logging
     printErr "Running GHC"
     xrefGraph <- runGhc (Just $ gaLibdirPrefix </> libdir) $ do
@@ -213,7 +213,6 @@ withTypechecked globalLock GhcArgs{..} analysisOpts xrefSink
 #endif
     mapM_ xrefSink xrefGraph
  where
-    errHandling = defaultErrorHandler defaultFatalMessager defaultFlushOut
     -- | RTS args would tune performance of the compilation. But we can't set
     -- them per-compilation from 'GhcApiSupport', so drop them.
     partitionRtsArgs :: [String] -> ([String], [String])

--- a/haskell-indexer-pipeline-ghckythe-wrapper/haskell-indexer-pipeline-ghckythe-wrapper.cabal
+++ b/haskell-indexer-pipeline-ghckythe-wrapper/haskell-indexer-pipeline-ghckythe-wrapper.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:    src
   build-depends:       base >=4.8 && <5
                      , bytestring
+                     , ghc
                      , haskell-indexer-backend-core >= 0.1
                      , haskell-indexer-backend-ghc >= 0.1
                      , haskell-indexer-pathutil >= 0.1

--- a/haskell-indexer-pipeline-ghckythe-wrapper/src/Language/Haskell/Indexer/Args.hs
+++ b/haskell-indexer-pipeline-ghckythe-wrapper/src/Language/Haskell/Indexer/Args.hs
@@ -45,6 +45,8 @@ import Language.Haskell.Indexer.Pipeline.GhcKythe (ghcToKythe, pluginContinuatio
 import Language.Haskell.Indexer.Util.Path (asTextPath, stripTmpPrefix)
 import Language.Haskell.Indexer.Translate
 
+import DynFlags (defaultFatalMessager, defaultFlushOut)
+import GHC (defaultErrorHandler)
 import GHC.IO.Handle
 
 -- | Command-line flags to control the indexer behavior.
@@ -122,7 +124,10 @@ flagParser = Flags
 index :: [String] -> Flags -> IO ()
 index args fs = do
     lock <- newMVar ()
-    indexX (ghcToKythe lock) args fs
+    withErrorHandler $ indexX (ghcToKythe lock) args fs
+  where
+    withErrorHandler :: IO a -> IO a
+    withErrorHandler = defaultErrorHandler defaultFatalMessager defaultFlushOut
 
 indexX
   :: (GhcArgs -> AnalysisOptions -> Raw.VName


### PR DESCRIPTION
Rather than just exiting on GHC errors, which is what
defaultErrorHandler does, passing them to the caller would give it a
better chance for handling them. E.g., they can do better logging.

This fixes https://github.com/google/haskell-indexer/issues/92.