### PR TITLE
Lightweight cabal wrapper & don't emit obsolete anchor -> file edges (fixes #115, fixes #13)

### DIFF
--- a/build-cabal.sh
+++ b/build-cabal.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Script for building Kythe index of Haskell packages using Cabal new-build.
+# See usage below.
+
+if (($# < 1)); then
+  echo "Usage: $0 package1 package2 ..." >&2
+  echo "Env variables with their defaults:" >&2
+  echo "  - INDEXER_OUTPUT_DIR=/tmp/indexer-output" >&2
+  echo "    Where to put indexing logs and output entries." >&2
+  exit 1
+fi
+
+# Directory where to build the index. Need to export it, so the GHC wrapper
+# executed as subprocess has access to it. Has to be an absolute path,
+# since the wrapper will be invoked in various directories.
+export INDEXER_OUTPUT_DIR=$(readlink -f "${INDEXER_OUTPUT_DIR:-/tmp/indexer-output}")
+[ ! -d "$INDEXER_OUTPUT_DIR" ] && mkdir -p "$INDEXER_OUTPUT_DIR"
+
+# REALGHC is used by the wrapper ghc. Note that it must be set before
+# altering the PATH.
+export REALGHC=$(which ghc)
+
+project_root=$(cd "$(dirname "$0")"; pwd)
+
+# Build and index the packages
+# ============================
+
+# The stack ghc wrapper works well for cabal too.
+cabal v2-build "${@:1}" --with-compiler="$project_root/wrappers/stack/ghc"
+

--- a/build-stack.sh
+++ b/build-stack.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script for building Kythe index of Haskell packages.
 # See usage below.

--- a/haskell-indexer-frontend-kythe/src/Language/Haskell/Indexer/Frontend/Kythe.hs
+++ b/haskell-indexer-frontend-kythe/src/Language/Haskell/Indexer/Frontend/Kythe.hs
@@ -68,6 +68,7 @@ toKythe basevn content XRef{..} = do
                           encodedContent
         env = ConversionEnv filevn pkgvn table basevn
         -- Files are children of the package they belong to.
+        -- This makes more sense for golang, but can't hurt here either.
         pkgFileEntry = edge filevn ChildOfE pkgvn
     sourceList (pkgFileEntry : pkgEntries ++ fileEntries)
     flip runReaderT env $ do
@@ -182,11 +183,9 @@ makeAnchor mbSource anchorEdge targetVName mbSnippet mbRefContext = do
             [ spanOrSubkindFacts
             , snippetFacts
             ]
-    childOfFile <- edge vname ChildOfE <$> asks fileVName
     let edgeEntries =
-            [ childOfFile
-            , edge vname (AnchorEdgeE anchorEdge) targetVName
-            ] ++ maybeToList (edge vname ChildOfE <$> mbRefContext)
+            edge vname (AnchorEdgeE anchorEdge) targetVName
+                : maybeToList (edge vname ChildOfE <$> mbRefContext)
     return $! nodeEntries ++ edgeEntries
   where
     implicits = ( implicitAnchorVName targetVName

--- a/kythe-verification/test.sh
+++ b/kythe-verification/test.sh
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 # TODO(robinp): take these from outer env if present.
-GHC_KYTHE=ghc_kythe_wrapper
+GHC_KYTHE="${GHC_KYTHE:-ghc_kythe_wrapper}"
 KYTHE_DIR="${KYTHE_DIR:-/opt/kythe}"
-VERIFIER=$KYTHE_DIR/tools/verifier
+VERIFIER="${VERIFIER:-$KYTHE_DIR/tools/verifier}"
 
 BASIC="testdata/basic"
 
@@ -55,7 +55,7 @@ for fut in \
     "$BASIC/TypeDef.hs"
 do
   echo "Verifying: $fut"
-  $GHC_KYTHE -- --check_for_singletons=true $fut 2> /dev/null | $VERIFIER -goal_prefix '-- -' $fut \
+  $GHC_KYTHE -- $fut 2> /dev/null | $VERIFIER -goal_prefix '-- -' --check_for_singletons=true $fut \
     || die
 done
 

--- a/kythe-verification/testdata/basic/Anchors.hs
+++ b/kythe-verification/testdata/basic/Anchors.hs
@@ -2,13 +2,9 @@ module Anchors where
 
 -- Anchors are childof the files they are defined in.
 -- - @f defines/binding FunF
--- - @f childof File
--- - File.node/kind file
 f =
     -- Kythe usually assign source anchors of ref/calls to their parent context.
     -- - @callMeMaybe childof FunF
-    -- - @callMeMaybe childof File
-    -- - @undefined childof File
     callMeMaybe undefined
 
 -- - @g defines/binding FunG
@@ -17,7 +13,6 @@ g = x
   -- Even calls of local bindings are put under the top-level scope, since
   -- fine-grained scoping is not a goal for Kythe.
   -- - @callMeMaybe childof FunG
-  -- - @x childof File
   where x = callMeMaybe undefined
 
 callMeMaybe :: Int -> Int

--- a/wrappers/stack/ghc
+++ b/wrappers/stack/ghc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/wrappers/stack/ghc
+++ b/wrappers/stack/ghc
@@ -50,6 +50,7 @@ if [[ "${@#--make}" != "$@" ]]; then
   fi
   log "== Output entries file: $ENTRIES_FILE"
   if ! ghc_kythe_wrapper \
+    --corpus haskell \
     --drop_path_prefix './' \
     --prepend_path_prefix "$PKG/" \
     $RENAME_MAIN \


### PR DESCRIPTION
The obsolete edges prevented index preprocessing from assembling the refs correctly (`write_tables` kythe tool with beam pipeline). Also fixes #115.