### PR TITLE
Cross-references for pattern synonyms.

### DIFF
--- a/haskell-indexer-backend-ghc/testdata/basic/PatSyn.hs
+++ b/haskell-indexer-backend-ghc/testdata/basic/PatSyn.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE PatternSynonyms #-}
+module PatSyn where
+
+pattern UniSingle a <- [a]
+
+uniAsPattern (UniSingle x) = x
+
+pattern BiSingle a = [a]
+
+biAsExpr x = BiSingle x
+
+biAsPattern (BiSingle x) = x

--- a/kythe-verification/test.sh
+++ b/kythe-verification/test.sh
@@ -49,6 +49,7 @@ for fut in \
     "$BASIC/ImpExpDefs.hs $BASIC/ImportRefs.hs" \
     "$BASIC/LocalRef.hs" \
     "$BASIC/Module.hs" \
+    "$BASIC/PatSyn.hs" \
     "$BASIC/RecordReadRef.hs" \
     "$BASIC/RecordWriteRef.hs" \
     "$BASIC/RecursiveRef.hs" \

--- a/kythe-verification/testdata/basic/PatSyn.hs
+++ b/kythe-verification/testdata/basic/PatSyn.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE PatternSynonyms #-}
+module PatSyn where
+
+-- - @UniSingle defines/binding PatUniSingle
+pattern UniSingle a <- [a]
+
+-- - @UniSingle ref PatUniSingle
+uniAsPattern (UniSingle x) = x
+
+-- - @BiSingle defines/binding PatBiSingle
+pattern BiSingle a = [a]
+
+-- - @BiSingle ref PatBiSingle
+biAsExpr x = BiSingle x
+
+-- - @BiSingle ref PatBiSingle
+biAsPattern (BiSingle x) = x


### PR DESCRIPTION
This fixes https://github.com/google/haskell-indexer/issues/75.