### PR TITLE
Pass `--ignore_dups` to Kythe verifier

### DIFF
--- a/kythe-verification/test.sh
+++ b/kythe-verification/test.sh
@@ -54,10 +54,11 @@ for fut in \
     "$BASIC/RecordWriteRef.hs" \
     "$BASIC/RecursiveRef.hs" \
     "$BASIC/TypeclassRef.hs" \
-    "$BASIC/TypeDef.hs"
+    "$BASIC/TypeDef.hs" \
+    "$BASIC/TypeVarInSig.hs"
 do
   echo "Verifying: $fut"
-  $GHC_KYTHE -- $fut 2> /dev/null | $VERIFIER -goal_prefix '-- -' --check_for_singletons=true $fut \
+  $GHC_KYTHE -- $fut 2> /dev/null | $VERIFIER -goal_prefix '-- -' --check_for_singletons=true --ignore_dups $fut \
     || die
 done
 

--- a/kythe-verification/testdata/basic/TypeVarInSig.hs
+++ b/kythe-verification/testdata/basic/TypeVarInSig.hs
@@ -1,0 +1,9 @@
+-- This file is just for checking that Kythe verifier doesn't fail with
+-- duplicate anchors when type variables are used in type signatures.
+module TypeVarInSig where
+
+-- The 'a' below causes duplicate anchors, and makes kythe-verifier fail
+-- without the `--ignore_dups` flag.
+isJust :: Maybe a -> Bool
+isJust (Just x) = True
+isJust Nothing = False


### PR DESCRIPTION
We sometimes generate multiple anchors with the same span. E.g., when a
type variable is used in type signatures, its first instance generates
both a decl anchor and a xref anchor. Just make the verifier ignore
them.

Fixes https://github.com/google/haskell-indexer/issues/123.