### PR TITLE
Fix wrong Hackage document URLs.

### DIFF
--- a/haskell-indexer-backend-ghc/haskell-indexer-backend-ghc.cabal
+++ b/haskell-indexer-backend-ghc/haskell-indexer-backend-ghc.cabal
@@ -22,7 +22,8 @@ library
                        Language.Haskell.Indexer.Backend.GhcArgs
                        Language.Haskell.Indexer.Backend.GhcApiSupport
                        Language.Haskell.Indexer.Backend.GhcEnv
-  build-depends:       base >=4.8 && <5
+  build-depends:       Cabal >= 2.4 && <3
+                     , base >=4.8 && <5
                      , containers
                      , directory
                      , filepath


### PR DESCRIPTION
My previous logic for determining whether to add a Hackage document URL
was too loose and added links even for some internal code (mostly for
generated code).

Now reads out the list of packages that are shipped with GHC and adds
a Hackage link only when the span doesn't exist *and* it comes from
those core package.