### PR TITLE
Don't generate module tickets for implicit imports (Prelude)

### DIFF
--- a/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
+++ b/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
@@ -557,14 +557,16 @@ relationsFromRenamed ctx declAlts (hsGroup, _, _, _) =
 
 -- | Exports module imports.
 importsFromRenamed :: GhcMonad m => ExtractCtx -> RenamedSource -> m [ModuleTick]
-importsFromRenamed ctx (_, lImportDecls, _, _) = mapM mkImport lImportDecls
+importsFromRenamed ctx (_, lImportDecls, _, _) =
+    catMaybes <$> mapM mkImport lImportDecls
   where
-    mkImport :: GhcMonad m => LImportDecl GhcRn -> m ModuleTick
-    mkImport (L _ implDecl) = do
-      pkgModule <- extractPkgModule . unLoc . ideclName $ implDecl
-      let pkgSpan = give ctx (srcSpanToSpan . getLoc $ ideclName implDecl)
-      return $ ModuleTick pkgModule pkgSpan
-
+    mkImport :: GhcMonad m => LImportDecl GhcRn -> m (Maybe ModuleTick)
+    mkImport (L _ implDecl)
+      | ideclImplicit implDecl = return Nothing
+      | otherwise = do
+          pkgModule <- extractPkgModule . unLoc . ideclName $ implDecl
+          let pkgSpan = give ctx (srcSpanToSpan . getLoc $ ideclName implDecl)
+          return $ Just $ ModuleTick pkgModule pkgSpan
     extractPkgModule :: GhcMonad m => ModuleName -> m PkgModule
     extractPkgModule name = findModule name Nothing >>= return . extractModuleName ctx
 

--- a/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
+++ b/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/Ghc.hs
@@ -562,6 +562,9 @@ importsFromRenamed ctx (_, lImportDecls, _, _) =
   where
     mkImport :: GhcMonad m => LImportDecl GhcRn -> m (Maybe ModuleTick)
     mkImport (L _ implDecl)
+        -- Implicit imports (Prelude) have no target nodes. Don't generate
+        -- tickets. Also the anchors are put to weird locations (the whole
+        -- module declaration), which is surprising to users.
       | ideclImplicit implDecl = return Nothing
       | otherwise = do
           pkgModule <- extractPkgModule . unLoc . ideclName $ implDecl


### PR DESCRIPTION
They generate lots of stray Kythe edges because the target nodes don't
exist. Their anchors span the whole module declaration (e.g., module
Foo.Bar where), which is not useful.

And this may be a problem once
https://github.com/google/haskell-indexer/issues/127 is fixed because
the module declaration lines will then link to the Hackage document for
Prelude, which will be surprising to users.