### PR TITLE
Add nix derivation; overrideable libdir for ghc_kythe_wrapper

### DIFF
--- a/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/GhcApiSupport.hs
+++ b/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/GhcApiSupport.hs
@@ -96,8 +96,11 @@ withTypechecked
 withTypechecked globalLock GhcArgs{..} analysisOpts xrefSink
         = withMVar globalLock . const $ do
     -- TODO(robinpalotai): logging
-    printErr "Running GHC"
-    let ghcLibDir = gaLibdirPrefix </> libdir
+    let ghcLibDir = case gaLibdirOverride of
+          Nothing -> libdir
+          Just (AddPrefixToLibdir prefix) -> prefix </> libdir
+          Just (OverrideLibdir path) -> path
+    printErr ("Running GHC, libdir: " ++ ghcLibDir)
     xrefGraph <- runGhc (Just ghcLibDir) $ do
         -- see GHC trac #4162
         liftIO . void $ installHandler sigINT Default Nothing

--- a/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/GhcArgs.hs
+++ b/haskell-indexer-backend-ghc/src/Language/Haskell/Indexer/Backend/GhcArgs.hs
@@ -11,29 +11,43 @@
 -- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
-
+{-# Language StrictData #-}
 module Language.Haskell.Indexer.Backend.GhcArgs
     ( GhcArgs(..)
     , ToolOverride(..)
+    , LibdirOverride(..)
     , defaultGhcArgs
     ) where
 
 -- | Args to call GHC with, to perform the compilation.
 data GhcArgs = GhcArgs
-    { gaToolOverride :: !ToolOverride
+    { gaToolOverride :: ToolOverride
     , gaArgs         :: [String]
-    , gaLibdirPrefix :: !FilePath
-      -- ^ Gets prepended to libdir path reported by ghc-paths. Needed if
-      -- runtime location of libdir differs from the reported one.
+    , gaLibdirOverride :: Maybe LibdirOverride
     }
 
 -- | Lets selective override of various tools used during compilation.
 data ToolOverride = ToolOverride
-    { overridePgmP :: !(Maybe FilePath)
+    { overridePgmP :: Maybe FilePath
       -- ^ Override the preprocessor if needed. Only overrides the binary, but
       -- keeps whatever flags were set on it originally (from the GHC command
       -- line).
     }
 
+-- | The libdir determines the default libraries available to GHC. Normally it
+-- is determined by calling a ghc-paths library function, but under special
+-- circumstances one might want to override it.
+data LibdirOverride
+    = AddPrefixToLibdir FilePath
+      -- ^ Prepend prefix to libdir.
+    | OverrideLibdir FilePath
+      -- ^ Explicit override.
+
 defaultGhcArgs :: GhcArgs
-defaultGhcArgs = GhcArgs (ToolOverride Nothing) [] ""
+defaultGhcArgs = GhcArgs
+    { gaToolOverride = ToolOverride
+        { overridePgmP = Nothing
+        }
+    , gaArgs = []
+    , gaLibdirOverride = Nothing
+    }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,31 @@
+{ pkgs ? import <nixpkgs> {}
+}:
+
+with {
+  haskellPackages = pkgs.haskellPackages.override (old: {
+    overrides =
+      with pkgs;
+      with {
+        indexerSrc = fetchgit {
+          url = "https://github.com/google/haskell-indexer";
+          sha256 = "0rr32birxd5xw85jyjx2q3dfgv7szpd142hbwf6isgiv3a3bhkx8";
+          rev = "08aed342bc76315534e7ee06ed497689276279e6";
+        };
+      };
+      lib.composeExtensions (old.overrides or (_: _: {})) (self: super: rec {
+        kythe-proto = haskell.lib.addBuildDepend (super.callPackage ./kythe-proto.nix { inherit indexerSrc; }) [protobuf];
+        kythe-schema = super.callPackage ./kythe-schema.nix { inherit indexerSrc; };
+        text-offset = super.callPackage ./text-offset.nix { inherit indexerSrc; };
+        haskell-indexer-backend-core = super.callPackage ./haskell-indexer-backend-core.nix { inherit indexerSrc; };
+        haskell-indexer-backend-ghc = super.callPackage ./haskell-indexer-backend-ghc.nix { inherit indexerSrc; };
+        haskell-indexer-frontend-kythe = super.callPackage ./haskell-indexer-frontend-kythe.nix { inherit indexerSrc; };
+        haskell-indexer-pathutil = super.callPackage ./haskell-indexer-pathutil.nix { inherit indexerSrc; };
+        haskell-indexer-pipeline-ghckythe = super.callPackage ./haskell-indexer-pipeline-ghckythe.nix { inherit indexerSrc; };
+        haskell-indexer-pipeline-ghckythe-wrapper = super.callPackage ./haskell-indexer-pipeline-ghckythe-wrapper.nix { inherit indexerSrc; };
+        haskell-indexer-translate = super.callPackage ./haskell-indexer-translate.nix { inherit indexerSrc; };
+      });
+  });
+};
+{
+  indexer = haskellPackages.haskell-indexer-pipeline-ghckythe-wrapper;
+}

--- a/nix/haskell-indexer-backend-core.nix
+++ b/nix/haskell-indexer-backend-core.nix
@@ -1,0 +1,12 @@
+{ mkDerivation, base, stdenv, text
+, indexerSrc }:
+mkDerivation {
+  pname = "haskell-indexer-backend-core";
+  version = "0.1.0.0";
+  src = indexerSrc;
+  postUnpack = "sourceRoot+=/haskell-indexer-backend-core; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [ base text ];
+  homepage = "https://github.com/google/haskell-indexer";
+  description = "Code common to all indexer backends";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/nix/haskell-indexer-backend-ghc.nix
+++ b/nix/haskell-indexer-backend-ghc.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, base, bytestring, Cabal, containers, directory
+, filepath, ghc, ghc-paths, hashable
+, haskell-indexer-backend-core, haskell-indexer-translate, HUnit
+, mtl, network-uri, reflection, semigroups, stdenv, temporary
+, test-framework, test-framework-hunit, text, text-offset
+, transformers, unix, unordered-containers
+, indexerSrc }:
+mkDerivation {
+  pname = "haskell-indexer-backend-ghc";
+  version = "0.1.0.0";
+  src = indexerSrc;
+  postUnpack = "sourceRoot+=/haskell-indexer-backend-ghc; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    base Cabal containers directory filepath ghc ghc-paths hashable
+    haskell-indexer-backend-core haskell-indexer-translate mtl
+    network-uri reflection text transformers unix unordered-containers
+  ];
+  testHaskellDepends = [
+    base bytestring directory filepath ghc haskell-indexer-backend-core
+    haskell-indexer-translate HUnit semigroups temporary test-framework
+    test-framework-hunit text text-offset transformers
+  ];
+  homepage = "https://github.com/google/haskell-indexer";
+  description = "Indexing code using GHC API";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/nix/haskell-indexer-frontend-kythe.nix
+++ b/nix/haskell-indexer-frontend-kythe.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, bytestring, conduit
+, haskell-indexer-translate, kythe-schema, mmorph, mtl, stdenv
+, text, text-offset, transformers
+, indexerSrc }:
+mkDerivation {
+  pname = "haskell-indexer-frontend-kythe";
+  version = "0.1.0.0";
+  src = indexerSrc;
+  postUnpack = "sourceRoot+=/haskell-indexer-frontend-kythe; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    base bytestring conduit haskell-indexer-translate kythe-schema
+    mmorph mtl text text-offset transformers
+  ];
+  homepage = "https://github.com/google/haskell-indexer";
+  description = "Emits Kythe schema based on translation layer data";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/nix/haskell-indexer-pathutil.nix
+++ b/nix/haskell-indexer-pathutil.nix
@@ -1,0 +1,12 @@
+{ mkDerivation, base, filepath, stdenv, text
+, indexerSrc}:
+mkDerivation {
+  pname = "haskell-indexer-pathutil";
+  version = "0.1.0.0";
+  src = indexerSrc;
+  postUnpack = "sourceRoot+=/haskell-indexer-pathutil; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [ base filepath text ];
+  homepage = "https://github.com/google/haskell-indexer";
+  description = "Utilities for dealing with filepaths";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/nix/haskell-indexer-pipeline-ghckythe-wrapper.nix
+++ b/nix/haskell-indexer-pipeline-ghckythe-wrapper.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, base, bytestring, ghc
+, haskell-indexer-backend-core, haskell-indexer-backend-ghc
+, haskell-indexer-pathutil, haskell-indexer-pipeline-ghckythe
+, haskell-indexer-translate, kythe-schema, optparse-applicative
+, proto-lens, stdenv, text
+, indexerSrc }:
+mkDerivation {
+  pname = "haskell-indexer-pipeline-ghckythe-wrapper";
+  version = "0.1.0.0";
+  src = indexerSrc;
+  postUnpack = "sourceRoot+=/haskell-indexer-pipeline-ghckythe-wrapper; echo source root reset to $sourceRoot";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base bytestring ghc haskell-indexer-backend-core
+    haskell-indexer-backend-ghc haskell-indexer-pathutil
+    haskell-indexer-pipeline-ghckythe haskell-indexer-translate
+    kythe-schema optparse-applicative proto-lens text
+  ];
+  executableHaskellDepends = [ base ];
+  homepage = "https://github.com/google/haskell-indexer";
+  description = "Executable able to take GHC arguments and emitting Kythe entries";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/nix/haskell-indexer-pipeline-ghckythe.nix
+++ b/nix/haskell-indexer-pipeline-ghckythe.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, bytestring, conduit, filepath
+, haskell-indexer-backend-core, haskell-indexer-backend-ghc
+, haskell-indexer-frontend-kythe, haskell-indexer-translate
+, kythe-schema, mmorph, mtl, stdenv, text
+, indexerSrc }:
+mkDerivation {
+  pname = "haskell-indexer-pipeline-ghckythe";
+  version = "0.1.0.0";
+  src = indexerSrc;
+  postUnpack = "sourceRoot+=/haskell-indexer-pipeline-ghckythe; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    base bytestring conduit filepath haskell-indexer-backend-core
+    haskell-indexer-backend-ghc haskell-indexer-frontend-kythe
+    haskell-indexer-translate kythe-schema mmorph mtl text
+  ];
+  homepage = "https://github.com/google/haskell-indexer";
+  description = "Gets GHC invocation arguments and streams Kythe entries";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/nix/haskell-indexer-translate.nix
+++ b/nix/haskell-indexer-translate.nix
@@ -1,0 +1,12 @@
+{ mkDerivation, base, bytestring, filepath, stdenv, text
+, indexerSrc }:
+mkDerivation {
+  pname = "haskell-indexer-translate";
+  version = "0.1.0.0";
+  src = indexerSrc;
+  postUnpack = "sourceRoot+=/haskell-indexer-translate; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [ base bytestring filepath text ];
+  homepage = "https://github.com/google/haskell-indexer";
+  description = "Translation layer isolating compiler backends from frontends";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/nix/kythe-proto.nix
+++ b/nix/kythe-proto.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, Cabal, proto-lens-runtime
+, proto-lens-setup, stdenv
+, indexerSrc }:
+mkDerivation {
+  pname = "kythe-proto";
+  version = "0.1.0.0";
+  src = indexerSrc;
+  postUnpack = "sourceRoot+=/kythe-proto; echo source root reset to $sourceRoot";
+  setupHaskellDepends = [ base Cabal proto-lens-setup ];
+  libraryHaskellDepends = [ base proto-lens-runtime ];
+  homepage = "https://github.com/google/haskell-indexer";
+  description = "Proto bindings for Kythe protobufs";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/nix/kythe-schema.nix
+++ b/nix/kythe-schema.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, bytestring, data-default
+, kythe-proto, lens-family, proto-lens, stdenv, text
+, indexerSrc }:
+mkDerivation {
+  pname = "kythe-schema";
+  version = "0.1.0.0";
+  src = indexerSrc;
+  postUnpack = "sourceRoot+=/kythe-schema; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    base bytestring data-default kythe-proto lens-family proto-lens
+    text
+  ];
+  homepage = "https://github.com/google/haskell-indexer";
+  description = "Library for emitting Kythe schema entries";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/nix/text-offset.nix
+++ b/nix/text-offset.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, base, bytestring, HUnit, QuickCheck
+, stdenv, test-framework, test-framework-hunit
+, test-framework-quickcheck2, text, vector
+, indexerSrc }:
+mkDerivation {
+  pname = "text-offset";
+  version = "0.1.0.0";
+  src = indexerSrc;
+  postUnpack = "sourceRoot+=/text-offset; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [ base text vector ];
+  testHaskellDepends = [
+    base bytestring HUnit QuickCheck test-framework
+    test-framework-hunit test-framework-quickcheck2 text
+  ];
+  homepage = "https://github.com/google/haskell-indexer";
+  description = "Library for converting between line/column and byte offset";
+  license = stdenv.lib.licenses.asl20;
+}


### PR DESCRIPTION
The nix derivation makes it easy to build with nix until all components land on hackage.

The libdir in ghc_kythe_wrapper needs to be passed in externally for the `rules_haskell` indexer aspect (see https://github.com/tweag/rules_haskell/pull/1236). This introduces a small breaking change around `GhcArgs`, but should be an easy upgrade for depending code.